### PR TITLE
[#6] Fix grpc diary

### DIFF
--- a/diary/src/main/kotlin/com/weltcorp/dta/waud/lib/diary/Api.kt
+++ b/diary/src/main/kotlin/com/weltcorp/dta/waud/lib/diary/Api.kt
@@ -2,19 +2,19 @@ package com.weltcorp.dta.waud.lib.diary
 
 class DiaryApiConfig private constructor (
     var host: String? = null,
-    var port: Int = 9090,
+    var port: Int? = null,
     var auth: String,
     var userId: Int = 0
 ) {
 
     data class Builder(
         var host: String = "localhost",
-        var port: Int = 9090,
+        var port: Int? = null,
         var auth: String = "",
         var userId: Int = 0
     ) {
         fun host(host: String) = apply { this.host = host }
-        fun port(port: Int) = apply { this.port = port }
+        fun port(port: Int?) = apply { this.port = port }
         fun auth(auth: String) = apply { this.auth = auth }
         fun userId(userId: Int) = apply { this.userId = userId }
         fun build() = DiaryApiConfig(host, port, auth, userId)

--- a/diary/src/main/kotlin/com/weltcorp/dta/waud/lib/diary/datasource/DiaryRemoteDataSourceGrpcImpl.kt
+++ b/diary/src/main/kotlin/com/weltcorp/dta/waud/lib/diary/datasource/DiaryRemoteDataSourceGrpcImpl.kt
@@ -9,11 +9,7 @@ import io.grpc.Metadata
 
 class DiaryRemoteDataSourceGrpcImpl(private val config: DiaryApiConfig) : RemoteDataSource {
 
-    private var _channel = ManagedChannelBuilder
-        .forAddress(config.host, config.port)
-        .usePlaintext()
-        .build()
-
+    private var _channel = getMangedChannel()
     private var _stub = DiariesDataGrpcKt.DiariesDataCoroutineStub(getChannel())
 
     private fun getHeader(): Metadata {
@@ -28,12 +24,18 @@ class DiaryRemoteDataSourceGrpcImpl(private val config: DiaryApiConfig) : Remote
 
     private fun getChannel(): ManagedChannel {
         if (_channel.isShutdown || _channel.isTerminated) {
-            _channel = ManagedChannelBuilder
-                .forAddress(config.host, config.port)
-                .usePlaintext()
-                .build()
+            _channel = getMangedChannel()
         }
         return _channel
+    }
+
+    private fun getMangedChannel(): ManagedChannel {
+        val channel = ManagedChannelBuilder
+            .forTarget("${config.host}${if (config.port != null) ":${config.port}" else ""}")
+        if (config.port != null) {
+            channel.usePlaintext()
+        }
+        return channel.build()
     }
 
     private fun stub(): DiariesDataGrpcKt.DiariesDataCoroutineStub {

--- a/src/main/kotlin/diary/GetDiaries.kt
+++ b/src/main/kotlin/diary/GetDiaries.kt
@@ -6,7 +6,7 @@ import com.weltcorp.dta.waud.lib.diary.datasource.DiaryRemoteDataSourceGrpcImpl
 suspend fun main(args: Array<String>) {
     val config = DiaryApiConfig.Builder()
         .host("localhost")
-        .port(24100)
+        .port(24100) // The port can be removed, if you don't need.
         .auth("<YOUR-TOKEN>")
         .userId(1)
         .build()


### PR DESCRIPTION
1. Make the port nullable.
2. Replaced the 'forAddress()' with 'forTarget()' to work even if the port value is null.
3. Invoke 'usePlaintext()' in case of local test only.


<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
